### PR TITLE
Add OSS list page with store integration

### DIFF
--- a/src/components/oss/OssFilterBar.vue
+++ b/src/components/oss/OssFilterBar.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-text-field
+    v-model="search"
+    append-inner-icon="mdi-magnify"
+    clearable
+    density="comfortable"
+    :label="label"
+    @click:append-inner="emitSearch"
+    @keyup.enter="emitSearch"
+  />
+</template>
+
+<script setup lang="ts">
+  interface Props {
+    name: string
+    label?: string
+  }
+
+  const props = defineProps<Props>()
+  const emit = defineEmits<{
+    (e: 'update:name', value: string): void
+    (e: 'search'): void
+  }>()
+
+  const search = computed({
+    get: () => props.name,
+    set: val => emit('update:name', val),
+  })
+
+  const label = computed(() => props.label ?? 'Search')
+
+  function emitSearch () {
+    emit('search')
+  }
+</script>

--- a/src/components/oss/OssTable.vue
+++ b/src/components/oss/OssTable.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-data-table
+    item-value="id"
+    :items="items"
+    :items-length="totalItems"
+    :items-per-page="itemsPerPage"
+    :loading="loading"
+    :page="page"
+    @update:items-per-page="(s) => emit('update:items-per-page', s)"
+    @update:page="(p) => emit('update:page', p)"
+  >
+    <template #headers>
+      <tr>
+        <th class="text-left">Name</th>
+        <th class="text-left">Layers</th>
+        <th class="text-left">Tags</th>
+      </tr>
+    </template>
+    <template #item="{ item }">
+      <tr>
+        <td>{{ item.name }}</td>
+        <td>{{ (item.layers || []).join(', ') }}</td>
+        <td>
+          <v-chip
+            v-for="tag in item.tags"
+            :key="tag.id"
+            class="ma-1"
+            size="small"
+            variant="tonal"
+          >{{ tag.name }}</v-chip>
+        </td>
+      </tr>
+    </template>
+  </v-data-table>
+</template>
+
+<script setup lang="ts">
+  import type { OssComponent } from '@/api'
+
+  interface Props {
+    items: OssComponent[]
+    loading: boolean
+    page: number
+    itemsPerPage: number
+    totalItems: number
+  }
+
+  defineProps<Props>()
+  const emit = defineEmits<{
+    (e: 'update:page' | 'update:items-per-page', value: number): void
+  }>()
+
+</script>

--- a/src/pages/OssListPage.vue
+++ b/src/pages/OssListPage.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-container fluid>
+    <OssFilterBar
+      v-model:name="filters.name"
+      class="mb-4"
+      @search="onSearch"
+    />
+    <OssTable
+      :items="list"
+      :items-per-page="size"
+      :loading="loading"
+      :page="page"
+      :total-items="total"
+      @update:items-per-page="onItemsPerPageChange"
+      @update:page="onPageChange"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+  import { useOssStore } from '@/stores/useOssStore'
+
+  const ossStore = useOssStore()
+  const { list, loading, page, size, total, filters } = storeToRefs(ossStore)
+  const { fetchList } = ossStore
+
+  onMounted(() => {
+    fetchList()
+  })
+
+  function onSearch () {
+    ossStore.page = 1
+    fetchList()
+  }
+
+  function onPageChange (p: number) {
+    ossStore.page = p
+    fetchList()
+  }
+
+  function onItemsPerPageChange (s: number) {
+    ossStore.page = 1
+    ossStore.size = s
+    fetchList()
+  }
+</script>


### PR DESCRIPTION
## Summary
- create `OssFilterBar` component for search input
- create `OssTable` component to display OSS data
- add `OssListPage` using `useOssStore` and new components

## Testing
- `npm run generate`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687f3d054bb4832083723bcaf70dd8e3