### PR TITLE
Add tag and scope policy settings

### DIFF
--- a/src/components/settings/ScopePolicyForm.vue
+++ b/src/components/settings/ScopePolicyForm.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <v-switch v-model="form.runtimeRequiredDefaultInScope" :label="$t('settings.policy.runtimeRequiredDefaultInScope')" />
+    <v-switch v-model="form.serverEnvIncluded" :label="$t('settings.policy.serverEnvIncluded')" />
+    <v-switch v-model="form.autoMarkForksInScope" :label="$t('settings.policy.autoMarkForksInScope')" />
+    <v-btn class="mt-4" color="primary" :loading="saving" @click="onSave">
+      {{ $t('settings.policy.save') }}
+    </v-btn>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { ScopePolicy } from '@/api'
+  import { storeToRefs } from 'pinia'
+  import { reactive, ref, watch } from 'vue'
+  import { useScopePolicyStore } from '@/stores/useScopePolicyStore'
+
+  const store = useScopePolicyStore()
+  const { policy } = storeToRefs(store)
+  const emit = defineEmits<{ (e: 'saved', policy: ScopePolicy): void }>()
+
+  const form = reactive({
+    runtimeRequiredDefaultInScope: false,
+    serverEnvIncluded: false,
+    autoMarkForksInScope: false,
+  })
+
+  watch(policy, p => {
+    if (p) {
+      form.runtimeRequiredDefaultInScope = p.runtimeRequiredDefaultInScope ?? false
+      form.serverEnvIncluded = p.serverEnvIncluded ?? false
+      form.autoMarkForksInScope = p.autoMarkForksInScope ?? false
+    }
+  }, { immediate: true })
+
+  const saving = ref(false)
+
+  async function onSave () {
+    saving.value = true
+    try {
+      const updated = await store.update({
+        runtimeRequiredDefaultInScope: form.runtimeRequiredDefaultInScope,
+        serverEnvIncluded: form.serverEnvIncluded,
+        autoMarkForksInScope: form.autoMarkForksInScope,
+      })
+      emit('saved', updated)
+    } catch (error) {
+      console.error(error)
+    } finally {
+      saving.value = false
+    }
+  }
+</script>

--- a/src/components/settings/TagManager.vue
+++ b/src/components/settings/TagManager.vue
@@ -1,0 +1,111 @@
+<template>
+  <div>
+    <v-row class="align-center" dense>
+      <v-col cols="8" sm="6">
+        <v-text-field
+          v-model="newTag"
+          density="comfortable"
+          hide-details
+          :label="$t('settings.tags.newTag')"
+          @keyup.enter="onAdd"
+        />
+      </v-col>
+      <v-col cols="4" sm="2">
+        <v-btn class="ma-0" color="primary" :loading="adding" @click="onAdd">
+          {{ $t('settings.tags.add') }}
+        </v-btn>
+      </v-col>
+    </v-row>
+    <div class="my-2">
+      <v-chip
+        v-for="tag in items"
+        :key="tag.id"
+        class="ma-1"
+        closable
+        size="small"
+        variant="tonal"
+        @click:close="openConfirm(tag)"
+      >{{ tag.name }}</v-chip>
+    </div>
+    <v-dialog v-model="confirmOpen" max-width="400">
+      <v-card>
+        <v-card-title>{{ $t('settings.tags.confirmDelete') }}</v-card-title>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn color="primary" :loading="deleting" @click="onDelete">
+            {{ $t('settings.policy.save') }}
+          </v-btn>
+          <v-btn text @click="confirmOpen = false">
+            {{ $t('project.detail.cancel') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+    <v-snackbar v-model="snackbar" timeout="3000">{{ snackbarMessage }}</v-snackbar>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { Tag } from '@/api'
+  import { storeToRefs } from 'pinia'
+  import { onMounted, ref } from 'vue'
+  import { useI18n } from 'vue-i18n'
+  import { useTagStore } from '@/stores/useTagStore'
+
+  const store = useTagStore()
+  const { items } = storeToRefs(store)
+  const { t } = useI18n()
+
+  const newTag = ref('')
+  const adding = ref(false)
+  const deleting = ref(false)
+  const confirmOpen = ref(false)
+  const target = ref<Tag>()
+  const snackbar = ref(false)
+  const snackbarMessage = ref('')
+
+  onMounted(() => {
+    store.fetch()
+  })
+
+  async function onAdd () {
+    if (!newTag.value) return
+    adding.value = true
+    try {
+      await store.create(newTag.value)
+      await store.fetch()
+      newTag.value = ''
+      showToast(t('settings.tags.added'))
+    } catch (error) {
+      console.error(error)
+    } finally {
+      adding.value = false
+    }
+  }
+
+  function openConfirm (tag: Tag) {
+    target.value = tag
+    confirmOpen.value = true
+  }
+
+  async function onDelete () {
+    if (!target.value) return
+    deleting.value = true
+    try {
+      await store.remove(target.value.id)
+      await store.fetch()
+      showToast(t('settings.tags.deleted'))
+    } catch (error) {
+      console.error(error)
+    } finally {
+      deleting.value = false
+      confirmOpen.value = false
+      target.value = undefined
+    }
+  }
+
+  function showToast (msg: string) {
+    snackbarMessage.value = msg
+    snackbar.value = true
+  }
+</script>

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -16,5 +16,23 @@
     "csv": "CSV",
     "spdx": "SPDX JSON",
     "toast": "エクスポートが完了しました"
+  },
+  "settings": {
+    "tags": {
+      "title": "タグ管理",
+      "newTag": "新規タグ",
+      "add": "追加",
+      "confirmDelete": "タグを削除しますか？",
+      "added": "タグを追加しました",
+      "deleted": "タグを削除しました"
+    },
+    "policy": {
+      "title": "スコープポリシー設定",
+      "runtimeRequiredDefaultInScope": "RUNTIME_REQUIRED を自動 IN_SCOPE",
+      "serverEnvIncluded": "SERVER_ENV を IN_SCOPE とみなす",
+      "autoMarkForksInScope": "INTERNAL_FORK を自動 IN_SCOPE",
+      "save": "保存",
+      "saved": "ポリシーを保存しました"
+    }
   }
 }

--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -1,0 +1,49 @@
+<template>
+  <v-container fluid>
+    <v-row>
+      <v-col cols="12" md="6">
+        <v-card>
+          <v-card-title>{{ $t('settings.tags.title') }}</v-card-title>
+          <v-card-text>
+            <TagManager />
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="6">
+        <v-card>
+          <v-card-title>{{ $t('settings.policy.title') }}</v-card-title>
+          <v-card-text>
+            <ScopePolicyForm @saved="onPolicySaved" />
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+    <v-snackbar v-model="snackbar" timeout="3000">{{ snackbarMessage }}</v-snackbar>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+  import { onMounted, ref } from 'vue'
+  import { useI18n } from 'vue-i18n'
+  import ScopePolicyForm from '@/components/settings/ScopePolicyForm.vue'
+  import TagManager from '@/components/settings/TagManager.vue'
+  import { useScopePolicyStore } from '@/stores/useScopePolicyStore'
+  import { useTagStore } from '@/stores/useTagStore'
+
+  const tagStore = useTagStore()
+  const policyStore = useScopePolicyStore()
+  const { t } = useI18n()
+
+  const snackbar = ref(false)
+  const snackbarMessage = ref('')
+
+  onMounted(() => {
+    tagStore.fetch()
+    policyStore.fetch()
+  })
+
+  function onPolicySaved () {
+    snackbarMessage.value = t('settings.policy.saved')
+    snackbar.value = true
+  }
+</script>

--- a/src/stores/useScopePolicyStore.ts
+++ b/src/stores/useScopePolicyStore.ts
@@ -1,0 +1,35 @@
+/* eslint-disable no-useless-catch */
+import type { ScopePolicy, ScopePolicyUpdateRequest } from '@/api'
+import { defineStore } from 'pinia'
+import { ScopePolicyService } from '@/api'
+
+export const useScopePolicyStore = defineStore('scopePolicy', {
+  state: () => ({
+    policy: null as ScopePolicy | null,
+    loading: false,
+  }),
+  actions: {
+    async fetch () {
+      this.loading = true
+      try {
+        this.policy = await ScopePolicyService.getScopePolicy()
+      } catch (error) {
+        throw error
+      } finally {
+        this.loading = false
+      }
+    },
+    async update (payload: ScopePolicyUpdateRequest) {
+      this.loading = true
+      try {
+        const updated = await ScopePolicyService.updateScopePolicy({ requestBody: payload })
+        this.policy = updated
+        return updated
+      } catch (error) {
+        throw error
+      } finally {
+        this.loading = false
+      }
+    },
+  },
+})

--- a/src/stores/useTagStore.ts
+++ b/src/stores/useTagStore.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-useless-catch */
+import type { Tag } from '@/api'
+import { defineStore } from 'pinia'
+import { TagsService } from '@/api'
+
+export const useTagStore = defineStore('tag', {
+  state: () => ({
+    items: [] as Tag[],
+    loading: false,
+  }),
+  actions: {
+    async fetch () {
+      this.loading = true
+      try {
+        this.items = await TagsService.listTags()
+      } catch (error) {
+        throw error
+      } finally {
+        this.loading = false
+      }
+    },
+    async create (name: string) {
+      try {
+        await TagsService.createTag({ requestBody: { name } })
+      } catch (error) {
+        throw error
+      }
+    },
+    async remove (id: string) {
+      try {
+        await TagsService.deleteTag({ tagId: id })
+      } catch (error) {
+        throw error
+      }
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- implement settings page with tag manager and scope policy form
- add TagManager and ScopePolicyForm components
- create Pinia stores for tags and scope policy
- localize settings UI messages

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run generate` *(fails: openapi spec missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f4640d28483209d4252e4df131b36