### PR TITLE
Implement global axios and toast utilities

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,3 +1,13 @@
 /// <reference types="vite/client" />
 /// <reference types="unplugin-vue-router/client" />
 /// <reference types="vite-plugin-vue-layouts-next/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string
+  readonly VITE_BASIC_USER: string
+  readonly VITE_BASIC_PASS: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,14 @@
 <template>
   <v-app>
     <router-view />
+    <v-snackbar v-model="visible" :color="color" timeout="3000">
+      {{ message }}
+    </v-snackbar>
   </v-app>
 </template>
 
 <script lang="ts" setup>
-  //
+  import { useToast } from '@/composables/useToast'
+
+  const { visible, message, color } = useToast()
 </script>

--- a/src/composables/useToast.ts
+++ b/src/composables/useToast.ts
@@ -1,0 +1,21 @@
+import { ref } from 'vue'
+
+const visible = ref(false)
+const message = ref('')
+const color = ref<'success' | 'error'>('success')
+
+export function useToast () {
+  function success (msg: string) {
+    message.value = msg
+    color.value = 'success'
+    visible.value = true
+  }
+
+  function error (msg: string) {
+    message.value = msg
+    color.value = 'error'
+    visible.value = true
+  }
+
+  return { visible, message, color, success, error }
+}

--- a/src/plugins/http.ts
+++ b/src/plugins/http.ts
@@ -1,0 +1,31 @@
+import type { ApiError, Problem } from '@/types/problem'
+import axios, { type AxiosError } from 'axios'
+
+axios.defaults.baseURL = import.meta.env.VITE_API_BASE_URL
+axios.defaults.timeout = 30_000
+
+axios.interceptors.request.use(config => {
+  const user = import.meta.env.VITE_BASIC_USER
+  const pass = import.meta.env.VITE_BASIC_PASS
+  const credentials = btoa(`${user}:${pass}`)
+  config.headers = config.headers || {}
+  if (!('Authorization' in config.headers)) {
+    config.headers['Authorization'] = `Basic ${credentials}`
+  }
+  return config
+})
+
+axios.interceptors.response.use(
+  response => response,
+  (error: AxiosError<Problem>) => {
+    const problem = error.response?.data
+    const apiError: ApiError = new Error(problem?.title || 'ネットワークエラー') as ApiError
+    apiError.status = error.response?.status
+    if (problem && problem.title) {
+      apiError.problem = problem
+    }
+    return Promise.reject(apiError)
+  },
+)
+
+export { default } from 'axios'

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -12,6 +12,8 @@ import pinia from '../stores'
 import i18n from './i18n'
 // Plugins
 import vuetify from './vuetify'
+// Http client (axios instance & interceptors)
+import './http'
 
 export function registerPlugins (app: App) {
   app

--- a/src/types/problem.ts
+++ b/src/types/problem.ts
@@ -1,0 +1,8 @@
+import type { Problem as OpenApiProblem } from '@/api'
+
+export interface Problem extends OpenApiProblem {}
+
+export interface ApiError extends Error {
+  status?: number
+  problem?: Problem
+}


### PR DESCRIPTION
## Summary
- create simple toast composable
- set up axios with basic auth and error handling
- load axios plugin during app startup
- display global snackbar in App
- expose Problem and ApiError types
- declare env vars

## Testing
- `npm run generate` *(fails: missing openapi.yaml)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687f4904a9648320917b319715095619