### PR TITLE
Setup pinia base and auth store

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { createApp } from 'vue'
 // Plugins
 import { registerPlugins } from '@/plugins'
 import { i18n } from '@/plugins/i18n'
+import pinia from '@/stores'
 
 // Components
 import App from './App.vue'
@@ -19,6 +20,7 @@ import 'unfonts.css'
 
 const app = createApp(App)
 
+app.use(pinia)
 registerPlugins(app)
 app.use(i18n)
 app.mount('#app')

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -7,7 +7,6 @@
 // Types
 import type { App } from 'vue'
 import router from '../router'
-import pinia from '../stores'
 
 // Plugins
 import vuetify from './vuetify'
@@ -18,5 +17,4 @@ export function registerPlugins (app: App) {
   app
     .use(vuetify)
     .use(router)
-    .use(pinia)
 }

--- a/src/stores/_base.ts
+++ b/src/stores/_base.ts
@@ -1,0 +1,8 @@
+export async function withLoading<T> (state: { loading: boolean }, fn: () => Promise<T>): Promise<T> {
+  state.loading = true
+  try {
+    return await fn()
+  } finally {
+    state.loading = false
+  }
+}

--- a/src/stores/auth/useAuthStore.ts
+++ b/src/stores/auth/useAuthStore.ts
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia'
+
+interface AuthState {
+  basicUser: string
+  basicPass: string
+  // future: jwtToken?: string
+}
+
+export const useAuthStore = defineStore('auth', {
+  state: (): AuthState => ({
+    basicUser: import.meta.env.VITE_BASIC_USER ?? '',
+    basicPass: import.meta.env.VITE_BASIC_PASS ?? '',
+  }),
+  actions: {
+    setBasic (user: string, pass: string) {
+      this.basicUser = user
+      this.basicPass = pass
+    },
+    // future: setJwt(token: string) { ... }
+  },
+})

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,4 +1,5 @@
-// Utilities
 import { createPinia } from 'pinia'
 
-export default createPinia()
+const pinia = createPinia()
+
+export default pinia

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -1,0 +1,13 @@
+export interface PagingQuery {
+  page: number
+  size: number
+}
+
+export interface PagingResult<T> {
+  items: T[]
+  page: number
+  size: number
+  total: number
+}
+
+export type { ApiError, Problem } from '@/types/problem'


### PR DESCRIPTION
## Summary
- initialize Pinia and export from stores entry
- provide common store types
- add basic auth store
- expose helper for loading handling
- mount Pinia in main app
- remove Pinia registration from plugin index

## Testing
- `npm run generate` *(fails: cannot find openapi spec)*
- `npm run lint`
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687f4e5e661c8320acfe0e5af78aad0a