### PR TITLE
Implement manual Vue Router setup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { createApp } from 'vue'
 // Plugins
 import { registerPlugins } from '@/plugins'
 import { i18n } from '@/plugins/i18n'
+import router from '@/router'
 import pinia from '@/stores'
 
 // Components
@@ -22,5 +23,6 @@ const app = createApp(App)
 
 app.use(pinia)
 registerPlugins(app)
+app.use(router)
 app.use(i18n)
 app.mount('#app')

--- a/src/pages/NotFoundPage.vue
+++ b/src/pages/NotFoundPage.vue
@@ -1,0 +1,21 @@
+<template>
+  <v-container class="text-center" fluid>
+    <v-row justify="center">
+      <v-col cols="12">
+        <h1>ページが見つかりません</h1>
+        <v-btn color="primary" @click="goHome">トップに戻る</v-btn>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+  import { useRouter } from 'vue-router'
+  import { RouteName } from '@/types/routes'
+
+  const router = useRouter()
+
+  function goHome () {
+    router.push({ name: RouteName.OssList })
+  }
+</script>

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -6,7 +6,6 @@
 
 // Types
 import type { App } from 'vue'
-import router from '../router'
 
 // Plugins
 import vuetify from './vuetify'
@@ -16,5 +15,4 @@ import './http'
 export function registerPlugins (app: App) {
   app
     .use(vuetify)
-    .use(router)
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,18 +1,46 @@
-/**
- * router/index.ts
- *
- * Automatic routes for `./src/pages/*.vue`
- */
+import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 
-/* eslint-disable import/no-duplicates */
-import { setupLayouts } from 'virtual:generated-layouts'
-// Composables
-import { createRouter, createWebHistory } from 'vue-router/auto'
-import { routes } from 'vue-router/auto-routes'
+import NotFoundPage from '@/pages/NotFoundPage.vue'
+import OssListPage from '@/pages/OssListPage.vue'
+import ProjectListPage from '@/pages/ProjectListPage.vue'
+import SettingsPage from '@/pages/SettingsPage.vue'
+
+import { RouteName } from '@/types/routes'
+
+const routes: RouteRecordRaw[] = [
+  {
+    path: '/',
+    name: RouteName.OssList,
+    component: OssListPage,
+  },
+  {
+    path: '/projects',
+    name: RouteName.ProjectList,
+    component: ProjectListPage,
+  },
+  {
+    path: '/settings',
+    name: RouteName.Settings,
+    component: SettingsPage,
+  },
+  {
+    path: '/:pathMatch(.*)*',
+    name: RouteName.NotFound,
+    component: NotFoundPage,
+  },
+]
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  routes: setupLayouts(routes),
+  routes,
+  scrollBehavior () {
+    return { top: 0 }
+  },
+})
+
+// TODO: add auth check when JWT authentication is introduced
+router.beforeEach((to, from, next) => {
+  next()
 })
 
 // Workaround for https://github.com/vitejs/vite/issues/11804

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -1,0 +1,6 @@
+export enum RouteName {
+  OssList = 'oss-list',
+  ProjectList = 'project-list',
+  Settings = 'settings',
+  NotFound = 'not-found',
+}


### PR DESCRIPTION
## Summary
- add route enum constants
- set up named routes with a not-found page
- register router plugin in main
- remove router from general plugin setup

## Testing
- `npm run generate`
- `npm run lint`
- `npm run type-check`
- `npm run dev` (smoke test)

------
https://chatgpt.com/codex/tasks/task_e_687f4fb9f92883208cd2823649689950