### PR TITLE
Implement main app layout with navigation drawer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,9 @@
 <template>
-  <v-app>
-    <router-view />
-    <AppToast />
-  </v-app>
+  <MainLayout />
+  <AppToast />
 </template>
 
 <script lang="ts" setup>
   import AppToast from '@/components/common/AppToast.vue'
+  import MainLayout from '@/layouts/MainLayout.vue'
 </script>

--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-app-bar app>
+    <v-app-bar-nav-icon @click="emit('toggle-nav')" />
+    <v-toolbar-title class="text-h6">{{ title }}</v-toolbar-title>
+    <div class="flex-grow-1" />
+  </v-app-bar>
+</template>
+
+<script setup lang="ts">
+  import { computed } from 'vue'
+  import { useI18n } from 'vue-i18n'
+  import { useRoute } from 'vue-router'
+
+  const emit = defineEmits<{ (e: 'toggle-nav'): void }>()
+
+  const route = useRoute()
+  const { t } = useI18n()
+
+  const title = computed(() => {
+    const key = route.meta.titleKey as string | undefined
+    return key ? t(key) : 'OSSカタログ管理'
+  })
+</script>

--- a/src/components/common/AppNavDrawer.vue
+++ b/src/components/common/AppNavDrawer.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-list density="compact" nav>
+    <v-list-item
+      v-for="item in items"
+      :key="item.titleKey"
+      :prepend-icon="item.icon"
+      router
+      :title="t(item.titleKey)"
+      :to="item.to"
+      @click="onNavigate"
+    />
+  </v-list>
+</template>
+
+<script setup lang="ts">
+  import type { RouteLocationRaw } from 'vue-router'
+  import { useI18n } from 'vue-i18n'
+
+  interface NavItem {
+    titleKey: string
+    icon: string
+    to: RouteLocationRaw
+  }
+
+  const emit = defineEmits<{ (e: 'navigate'): void }>()
+
+  const { t } = useI18n()
+
+  const items: NavItem[] = [
+    { titleKey: 'oss.listTitle', icon: 'mdi-package-variant', to: { name: 'oss-list' } },
+    { titleKey: 'project.listTitle', icon: 'mdi-briefcase', to: { name: 'project-list' } },
+    { titleKey: 'settings.title', icon: 'mdi-cog', to: { name: 'settings' } },
+  ]
+
+  function onNavigate () {
+    emit('navigate')
+  }
+</script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,0 +1,41 @@
+<template>
+  <v-app>
+    <v-navigation-drawer
+      v-model="drawer"
+      app
+      :permanent="!display.mobile.value"
+      :temporary="display.mobile.value"
+    >
+      <AppNavDrawer @navigate="onNavigate" />
+    </v-navigation-drawer>
+
+    <AppHeader @toggle-nav="toggleDrawer" />
+
+    <v-main>
+      <router-view />
+    </v-main>
+  </v-app>
+</template>
+
+<script setup lang="ts">
+  import { ref, watch } from 'vue'
+  import { useDisplay } from 'vuetify'
+
+  import AppHeader from '@/components/common/AppHeader.vue'
+  import AppNavDrawer from '@/components/common/AppNavDrawer.vue'
+
+  const drawer = ref(true)
+  const display = useDisplay()
+
+  watch(() => display.mobile.value, val => {
+    if (!val) drawer.value = true
+  })
+
+  function toggleDrawer () {
+    drawer.value = !drawer.value
+  }
+
+  function onNavigate () {
+    if (display.mobile.value) drawer.value = false
+  }
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -12,16 +12,19 @@ const routes: RouteRecordRaw[] = [
     path: '/',
     name: RouteName.OssList,
     component: OssListPage,
+    meta: { titleKey: 'oss.listTitle' },
   },
   {
     path: '/projects',
     name: RouteName.ProjectList,
     component: ProjectListPage,
+    meta: { titleKey: 'project.listTitle' },
   },
   {
     path: '/settings',
     name: RouteName.Settings,
     component: SettingsPage,
+    meta: { titleKey: 'settings.title' },
   },
   {
     path: '/:pathMatch(.*)*',


### PR DESCRIPTION
## Summary
- introduce `MainLayout` containing navigation drawer, header and main content area
- add `AppHeader` and `AppNavDrawer` components
- wire `MainLayout` and global toast in `App.vue`
- highlight current page using router meta titles

## Testing
- `npm run generate` *(fails: openapi spec missing)*
- `npm run lint`
- `npm run type-check`
- `npm run dev` *(manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_687f50cc6f74832090ba1c4359fdaedf