### PR TITLE
Add OSS create button

### DIFF
--- a/src/components/oss/OssDetailDialog.vue
+++ b/src/components/oss/OssDetailDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="modelOpen" max-width="600">
     <v-card>
-      <v-card-title>{{ isNew ? 'Create OSS' : 'Edit OSS' }}</v-card-title>
+      <v-card-title>{{ isNew ? t('oss.detail.titleNew') : t('oss.detail.titleEdit') }}</v-card-title>
       <v-card-text>
         <v-form ref="formRef">
           <v-text-field v-model="form.name" label="Name" required />
@@ -12,8 +12,8 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn color="primary" :loading="saving" @click="onSave">Save</v-btn>
-        <v-btn text @click="close">Cancel</v-btn>
+        <v-btn color="primary" :loading="saving" @click="onSave">{{ t('oss.detail.save') }}</v-btn>
+        <v-btn text @click="close">{{ t('oss.detail.cancel') }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -22,6 +22,7 @@
 <script setup lang="ts">
   import type { OssComponentCreateRequest, OssComponentUpdateRequest } from '@/api'
   import { computed, reactive, ref, watch } from 'vue'
+  import { useI18n } from 'vue-i18n'
   import { OssService } from '@/api'
 
   interface Props {
@@ -34,6 +35,8 @@
     (e: 'update:open', value: boolean): void
     (e: 'saved'): void
   }>()
+
+  const { t } = useI18n()
 
   const modelOpen = computed({
     get: () => props.open,

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -30,7 +30,13 @@
       "tags": "タグ",
       "deprecated": "非推奨"
     },
-    "detailTitle": "OSS詳細"
+    "detailTitle": "OSS詳細",
+    "detail": {
+      "titleNew": "OSS作成",
+      "titleEdit": "OSS編集",
+      "save": "保存",
+      "cancel": "キャンセル"
+    }
   },
   "project": {
     "listTitle": "プロジェクト一覧",

--- a/src/pages/OssListPage.vue
+++ b/src/pages/OssListPage.vue
@@ -14,15 +14,24 @@
       @update:items-per-page="onItemsPerPageChange"
       @update:page="onPageChange"
     />
+    <OssDetailDialog v-model:open="detailOpen" @saved="onSaved" />
+    <v-btn class="fab" color="primary" icon="mdi-plus" @click="openCreate" />
+    <v-snackbar v-model="snackbar" timeout="3000">{{ snackbarMessage }}</v-snackbar>
   </v-container>
 </template>
 
 <script setup lang="ts">
   import { useOssStore } from '@/stores/useOssStore'
+  import { useI18n } from 'vue-i18n'
 
   const ossStore = useOssStore()
   const { list, loading, page, size, total, filters } = storeToRefs(ossStore)
   const { fetchList } = ossStore
+
+  const { t } = useI18n()
+  const detailOpen = ref(false)
+  const snackbar = ref(false)
+  const snackbarMessage = ref('')
 
   onMounted(() => {
     fetchList()
@@ -43,4 +52,26 @@
     ossStore.size = s
     fetchList()
   }
+
+  function openCreate () {
+    detailOpen.value = true
+  }
+
+  async function onSaved () {
+    await fetchList()
+    showToast(t('toast.saved'))
+  }
+
+  function showToast (msg: string) {
+    snackbarMessage.value = msg
+    snackbar.value = true
+  }
 </script>
+
+<style scoped>
+.fab {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add localized labels for OSS detail dialog
- integrate i18n in `OssDetailDialog.vue`
- add floating action button on OSS list page with snackbar

## Testing
- `npm run generate` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*
- `npm run type-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6ac0279c8320909e7a1845531039