### PR TITLE
Make API endpoint runtime configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ yarn build
 
 Once the build process is completed, your application will be ready for deployment in a production environment.
 
+### API Endpoint Configuration
+
+The frontend reads its API base URL from `public/config.json` at runtime. After deployment,
+edit this file to point to your backend server:
+
+```json
+{
+  "apiBaseUrl": "https://api.example.local/api/v1"
+}
+```
+
+No rebuild is required when `config.json` is modified.
+
 ## 💪 Support Vuetify Development
 
 This project is built with [Vuetify](https://vuetifyjs.com/en/), a UI Library with a comprehensive collection of Vue components. Vuetify is an MIT licensed Open Source project that has been made possible due to the generous contributions by our [sponsors and backers](https://vuetifyjs.com/introduction/sponsors-and-backers/). If you are interested in supporting this project, please consider:

--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,3 @@
+{
+  "apiBaseUrl": "https://api.example.local/api/v1"
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,23 @@
+export interface AppConfig {
+  apiBaseUrl: string
+}
+
+let config: AppConfig = {
+  apiBaseUrl: 'https://api.example.local/api/v1',
+}
+
+export async function loadConfig (): Promise<AppConfig> {
+  try {
+    const res = await fetch('/config.json')
+    if (res.ok) {
+      config = await res.json()
+    }
+  } catch {
+    // ignore errors and use defaults
+  }
+  return config
+}
+
+export function getConfig (): AppConfig {
+  return config
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,10 @@
 // Composables
 import { createApp } from 'vue'
 
+import { loadConfig } from '@/config'
 // Plugins
 import { registerPlugins } from '@/plugins'
+import { configureHttp } from '@/plugins/http'
 import { i18n } from '@/plugins/i18n'
 import router from '@/router'
 import pinia from '@/stores'
@@ -19,10 +21,17 @@ import App from './App.vue'
 // Styles
 import 'unfonts.css'
 
-const app = createApp(App)
+async function bootstrap () {
+  const cfg = await loadConfig()
+  configureHttp(cfg)
 
-app.use(pinia)
-registerPlugins(app)
-app.use(router)
-app.use(i18n)
-app.mount('#app')
+  const app = createApp(App)
+
+  app.use(pinia)
+  registerPlugins(app)
+  app.use(router)
+  app.use(i18n)
+  app.mount('#app')
+}
+
+bootstrap()

--- a/src/plugins/http.ts
+++ b/src/plugins/http.ts
@@ -1,8 +1,13 @@
+import type { AppConfig } from '@/config'
 import type { ApiError, Problem } from '@/types/problem'
 import axios, { type AxiosError } from 'axios'
+import { OpenAPI } from '@/api'
 
-axios.defaults.baseURL = import.meta.env.VITE_API_BASE_URL
-axios.defaults.timeout = 30_000
+export function configureHttp (config: AppConfig) {
+  axios.defaults.baseURL = config.apiBaseUrl
+  axios.defaults.timeout = 30_000
+  OpenAPI.BASE = config.apiBaseUrl
+}
 
 axios.interceptors.request.use(config => {
   const user = import.meta.env.VITE_BASIC_USER

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -9,8 +9,6 @@ import type { App } from 'vue'
 
 // Plugins
 import vuetify from './vuetify'
-// Http client (axios instance & interceptors)
-import './http'
 
 export function registerPlugins (app: App) {
   app


### PR DESCRIPTION
## Summary
- load API settings from `public/config.json`
- configure axios/OpenAPI base URL at runtime
- bootstrap the app after loading configuration
- mention the configuration file in README

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run generate`


------
https://chatgpt.com/codex/tasks/task_e_687f79a0479c8320868b1f14ff06377e